### PR TITLE
removing sync trait requirement from error

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -2,7 +2,7 @@ use super::{Sender, Receiver, channel};
 
 #[test]
 fn basic() {
-    let (sx, rx): (Sender<usize, ()>, Receiver<usize, ()>) = channel();
+    let (sx, mut rx): (Sender<usize, ()>, Receiver<usize, ()>) = channel();
 
     sx.send(5usize).unwrap();
     sx.send(6usize).unwrap();
@@ -16,7 +16,7 @@ fn basic() {
 
 #[test]
 fn error() {
-    let (sx, rx) = channel();
+    let (sx, mut rx)  = channel();
 
     sx.send(5usize).unwrap();
     sx.error("hi".to_string()).unwrap();
@@ -26,27 +26,6 @@ fn error() {
     assert!(rx.is_closed());
     assert!(rx.has_error());
     assert!(rx.take_error() == Some("hi".to_string()))
-}
-
-#[test]
-fn iter() {
-    let (sx, rx): (Sender<usize, ()>, Receiver<usize, ()>) = channel();
-
-    sx.send(5usize).unwrap();
-    sx.send(7).unwrap();
-    sx.send(9).unwrap();
-
-    let mut rx = rx.iter();
-
-    let xs: Vec<usize> = rx.by_ref().collect();
-    assert!(xs == vec![5,7,9]);
-
-    sx.send(1).unwrap();
-    sx.send(2).unwrap();
-    sx.send(3).unwrap();
-
-    let ys: Vec<usize> = rx.collect();
-    assert!(ys == vec![1,2,3]);
 }
 
 #[test]
@@ -70,32 +49,3 @@ fn into_iter() {
     assert!(ys == vec![1,2,3]);
 }
 
-#[test]
-fn iter_block() {
-    // close()
-    {
-        let (sx, rx): (Sender<usize, ()>, Receiver<usize, ()>) = channel();
-
-        sx.send(5usize).unwrap();
-        sx.send(7usize).unwrap();
-        sx.send(9usize).unwrap();
-        sx.close(); // this close is required
-
-        let rx = rx.blocking_iter();
-        let xs: Vec<usize> = rx.collect();
-        assert!(xs == vec![5,7,9]);
-    }
-    // error()
-    {
-        let (sx, rx): (Sender<usize, ()>, Receiver<usize, ()>) = channel();
-
-        sx.send(5usize).unwrap();
-        sx.send(7usize).unwrap();
-        sx.send(9usize).unwrap();
-        sx.error(()).unwrap(); // this error is required
-
-        let rx = rx.blocking_iter();
-        let xs: Vec<usize> = rx.collect();
-        assert!(xs == vec![5,7,9]);
-    }
-}


### PR DESCRIPTION
Basically the original author probably ran into [this issue](http://stackoverflow.com/questions/25730586/returning-mutable-references-from-an-iterator). To break the immutability, he used `RwLock`, which required all error types to support the `Sync` trait. Theres another type specifically for this usage, `Cell`, but it requires that the Error have a `Copy` trait, which they don't. So rather than fool with the unsafe code, I just removed the non-consuming iterators. Sorry.
